### PR TITLE
 add MultiExec.add(*Commands)

### DIFF
--- a/reddish/_command.py
+++ b/reddish/_command.py
@@ -140,6 +140,9 @@ class MultiExec:
         """
         self._commands = commands
 
+    def add(self, *commands: Command):
+        self._commands += commands
+
     def __repr__(self) -> str:
         commands = (repr(cmd) for cmd in self._commands)
         return f"{self.__class__.__name__}({', '.join(commands)})"


### PR DESCRIPTION
Adds ```add``` to ```MultiExec``` to add Commands.

use: 

```python

from reddish.trio import MultiExec, Command

tx = MultiExec(
    Command('ECHO {}', 'foo'),
    Command('ECHO {}', 'bar')
)
# ... same code hire 

tx.add(
    Command('ECHO {}', 'baz'),
    Command('ECHO {}', 'qux')
)
foo, bar, baz, qux = await redis.execute(tx)
```