### PR TITLE
add type published to github action pypi_release

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -2,6 +2,7 @@ name: pypi_release
 
 on:
   release:
+    types: [published]
 
 jobs:
   pypi_release:


### PR DESCRIPTION
Update GitHub Action for PyPi Release.
```yaml 
on:
  release:
    types: [published]
```
This way the action is executed only once instead of 3 times