### PR TITLE
New error system

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -268,7 +268,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:c9ba9a76fdfdbba3f3bbaaca9f3998f67de2556eb51bbb5e68041c67afe810bf"
+content_hash = "sha256:a28db939e85248a75a75c6f5635170e78f0f024d183811c33a3f79711e9b0487"
 
 [metadata.files]
 "async-generator 1.10" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ authors = [
 dependencies = [
     "hiredis>=2.2.2",
     "pydantic>=1.10.6",
+    "outcome>=1.2.0",
 ]
 requires-python = ">=3.7"
 readme = "README.md"

--- a/src/reddish/__init__.py
+++ b/src/reddish/__init__.py
@@ -1,2 +1,8 @@
 from reddish._core.command import Args, Command  # noqa
 from reddish._core.multiexec import MultiExec  # noqa
+from reddish._core.errors import (  # noqa
+    CommandError,
+    ParseError,
+    PipelineError,
+    TransactionError,
+)

--- a/src/reddish/_core/command.py
+++ b/src/reddish/_core/command.py
@@ -6,7 +6,7 @@ from copy import copy
 from typing import Union
 from hiredis import ReplyError
 
-from .parser import parse, ParseError
+from .parser import parse
 from .utils import to_bytes, to_resp_array, strip_whitespace
 from .templating import apply_template
 from .errors import CommandError
@@ -96,7 +96,6 @@ class Command:
         return new
 
     def _parse_response(self, response):
-
         if isinstance(response, ReplyError):
             raise CommandError(str(response)) from None
 

--- a/src/reddish/_core/command.py
+++ b/src/reddish/_core/command.py
@@ -4,10 +4,12 @@ from itertools import chain
 from copy import copy
 
 from typing import Union
+from hiredis import ReplyError
 
 from .parser import parse, ParseError
 from .utils import to_bytes, to_resp_array, strip_whitespace
 from .templating import apply_template
+from .errors import CommandError
 
 
 AtomicType = Union[int, float, str, bytes]
@@ -94,14 +96,15 @@ class Command:
         return new
 
     def _parse_response(self, response):
+
+        if isinstance(response, ReplyError):
+            raise CommandError(str(response)) from None
+
         if not self._models:  # skip parsing
             return response
 
         for model in self._models:
-            try:
-                response = parse(model, response)
-            except ParseError as error:
-                return error
+            response = parse(model, response)
 
         return response
 

--- a/src/reddish/_core/errors.py
+++ b/src/reddish/_core/errors.py
@@ -2,7 +2,9 @@ from outcome import Outcome
 from typing import Iterable
 
 
-class BrokenConnectionError(Exception):
+class ConnectionError(Exception):
+    """Raised when the underlying connection closed or failed."""
+
     def __init__(self, msg="Connection closed.", *args, **kwargs):
         super().__init__(msg, *args, **kwargs)
 

--- a/src/reddish/_core/errors.py
+++ b/src/reddish/_core/errors.py
@@ -20,6 +20,26 @@ class CommandError(Exception):
         self.code, self.message = str(reply).split(maxsplit=1)
 
 
+class ParseError(Exception):
+    """Raised for commands where reply does not parse successfully.
+
+    The original reply and the type that it failed to be parsed into as attributed
+    `.reply` and `.type`
+    """
+
+    def __init__(self, reply, type):
+        self._reply = reply
+        self._type = type
+
+    @property
+    def reply(self):
+        return self._reply
+
+    @property
+    def type(self):
+        return self._type
+
+
 class PipelineError(Exception):
     """Raised when one or more pipelined commands resulted in an error.
 

--- a/src/reddish/_core/errors.py
+++ b/src/reddish/_core/errors.py
@@ -19,6 +19,9 @@ class CommandError(Exception):
     def __init__(self, reply: str):
         self.code, self.message = str(reply).split(maxsplit=1)
 
+    def __str__(self):
+        return f"{self.code} {self.message}"
+
 
 class ParseError(Exception):
     """Raised for commands where reply does not parse successfully.
@@ -38,6 +41,9 @@ class ParseError(Exception):
     @property
     def type(self):
         return self._type
+
+    def __str__(self):
+        return f"{self.reply} cannot be parsed into {self.type}"
 
 
 class PipelineError(Exception):

--- a/src/reddish/_core/errors.py
+++ b/src/reddish/_core/errors.py
@@ -1,3 +1,7 @@
+from outcome import Outcome
+from typing import Iterable
+
+
 class BrokenConnectionError(Exception):
     def __init__(self, msg="Connection closed.", *args, **kwargs):
         super().__init__(msg, *args, **kwargs)
@@ -16,3 +20,32 @@ class CommandError(Exception):
 
     def __init__(self, reply: str):
         self.code, self.message = str(reply).split(maxsplit=1)
+
+
+class PipelineError(Exception):
+    """Raised when one or more pipelined commands resulted in an error.
+
+    The values and/or errors are made available as `Outcome` objects and can be
+    iterated over by iterating this exception.
+    """
+
+    def __init__(self, outcomes: Iterable[Outcome]):
+        self._outcomes = outcomes
+
+    def __iter__(self):
+        yield from self._outcomes
+
+
+class TransactionError(Exception):
+    """Raised when one or more commands in a Multi/Exec transaction
+    resulted in an error.
+
+    The values and/or errors are made available as `Outcome` objects and can be
+    iterated over by iterating this exception.
+    """
+
+    def __init__(self, outcomes: Iterable[Outcome]):
+        self._outcomes = outcomes
+
+    def __iter__(self):
+        yield from self._outcomes

--- a/src/reddish/_core/errors.py
+++ b/src/reddish/_core/errors.py
@@ -1,7 +1,3 @@
-from outcome import Outcome
-from typing import Iterable
-
-
 class ConnectionError(Exception):
     """Raised when the underlying connection closed or failed."""
 
@@ -31,11 +27,12 @@ class PipelineError(Exception):
     iterated over by iterating this exception.
     """
 
-    def __init__(self, outcomes: Iterable[Outcome]):
+    def __init__(self, outcomes):
         self._outcomes = outcomes
 
-    def __iter__(self):
-        yield from self._outcomes
+    @property
+    def outcomes(self):
+        return self._outcomes
 
 
 class TransactionError(Exception):
@@ -46,8 +43,9 @@ class TransactionError(Exception):
     iterated over by iterating this exception.
     """
 
-    def __init__(self, outcomes: Iterable[Outcome]):
+    def __init__(self, outcomes):
         self._outcomes = outcomes
 
-    def __iter__(self):
-        yield from self._outcomes
+    @property
+    def outcomes(self):
+        return self._outcomes

--- a/src/reddish/_core/errors.py
+++ b/src/reddish/_core/errors.py
@@ -5,3 +5,14 @@ class BrokenConnectionError(Exception):
 
 class UnsupportedCommandError(Exception):
     pass
+
+
+class CommandError(Exception):
+    """Raised for Redis error replies.
+
+    The original error code and message are available as
+    attributes `.code` and `.message`.
+    """
+
+    def __init__(self, reply: str):
+        self.code, self.message = str(reply).split(maxsplit=1)

--- a/src/reddish/_core/multiexec.py
+++ b/src/reddish/_core/multiexec.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 
 from typing import Union
 
-from outcome import capture, Value, Error
+from outcome import capture, Error
 from hiredis import ReplyError
 
 from .utils import to_resp_array

--- a/src/reddish/_core/parser.py
+++ b/src/reddish/_core/parser.py
@@ -1,12 +1,9 @@
 from pydantic import parse_obj_as, ValidationError
-
-
-class ParseError(Exception):
-    pass
+from reddish._core.errors import ParseError
 
 
 def parse(type_, value):
     try:
         return parse_obj_as(type_, value)
     except ValidationError as error:
-        raise ParseError(f"`{repr(value)}` could not be parsed as `{type_}`") from error
+        raise ParseError(value, type_) from error

--- a/src/reddish/_core/sansio.py
+++ b/src/reddish/_core/sansio.py
@@ -1,7 +1,7 @@
 import hiredis
 from .utils import partition
 from .multiexec import MultiExec
-from .errors import UnsupportedCommandError, BrokenConnectionError
+from .errors import UnsupportedCommandError, ConnectionError
 
 
 class ReplyBuffer:
@@ -46,7 +46,7 @@ class RedisSansIO:
 
     def send(self, commands):
         if self._broken:
-            raise BrokenConnectionError()
+            raise ConnectionError()
         if self._reply_buffer is not None:
             raise ProtocolError("Cannot send more commands")
         for cmd in commands:
@@ -58,7 +58,7 @@ class RedisSansIO:
         reply_buffer = self._reply_buffer
 
         if self._broken:
-            raise BrokenConnectionError()
+            raise ConnectionError()
         if reply_buffer is None:
             raise ProtocolError(
                 "Cannot receive replies because no commands where queued"

--- a/src/reddish/socket/_client.py
+++ b/src/reddish/socket/_client.py
@@ -1,7 +1,7 @@
 import socket
 import threading
 from reddish._core.sansio import RedisSansIO
-from reddish._core.errors import BrokenConnectionError
+from reddish._core.errors import ConnectionError
 
 from reddish._core.typing import CommandType
 
@@ -46,13 +46,13 @@ class Redis:
                 while True:
                     data = stream.recv(4096)
                     if data == b"":
-                        raise BrokenConnectionError()
+                        raise ConnectionError()
                     replies = redis.receive(data)
                     if replies:
                         return replies
             except OSError:
                 redis.mark_broken()
-                raise BrokenConnectionError()
+                raise ConnectionError()
 
     def execute(self, command: CommandType):
         """Execute a single redis command.

--- a/src/reddish/trio/_client.py
+++ b/src/reddish/trio/_client.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     raise ImportError("Execute 'pip install reddish[trio]' to enable trio support")
 from reddish._core.sansio import RedisSansIO
-from reddish._core.errors import BrokenConnectionError
+from reddish._core.errors import ConnectionError
 
 from reddish._core.typing import CommandType
 
@@ -44,13 +44,13 @@ class Redis:
                 while True:
                     data = await stream.receive_some()
                     if data == b"":
-                        raise BrokenConnectionError()
+                        raise ConnectionError()
                     replies = redis.receive(data)
                     if replies:
                         return replies
             except (trio.BrokenResourceError, trio.ClosedResourceError):
                 redis.mark_broken()
-                raise BrokenConnectionError()
+                raise ConnectionError()
             except trio.Cancelled:
                 redis.mark_broken()
                 raise

--- a/tests/socket/test_socket.py
+++ b/tests/socket/test_socket.py
@@ -3,7 +3,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from reddish.socket import Redis, Command
-from reddish._core.errors import BrokenConnectionError
+from reddish._core.errors import ConnectionError
 
 
 @pytest.fixture
@@ -44,7 +44,7 @@ def test_stream(unconnected_socket):
 def test_closed_connection(connected_socket, ping):
     redis = Redis(connected_socket)
     connected_socket.close()
-    with pytest.raises(BrokenConnectionError):
+    with pytest.raises(ConnectionError):
         redis.execute(ping)
 
 

--- a/tests/test_RedisSansIO.py
+++ b/tests/test_RedisSansIO.py
@@ -1,7 +1,7 @@
 import pytest
 from reddish._core import Command, MultiExec
 from reddish._core.sansio import RedisSansIO, ProtocolError
-from reddish._core.errors import UnsupportedCommandError, BrokenConnectionError
+from reddish._core.errors import UnsupportedCommandError, ConnectionError
 
 
 @pytest.fixture
@@ -46,13 +46,13 @@ def test_receiving_without_send_should_raise(redis):
 
 def test_broken_connection_send(redis):
     redis.mark_broken()
-    with pytest.raises(BrokenConnectionError):
+    with pytest.raises(ConnectionError):
         redis.send(ping)
 
 
 def test_broken_connection_receive(redis):
     redis.mark_broken()
-    with pytest.raises(BrokenConnectionError):
+    with pytest.raises(ConnectionError):
         redis.receive(b"")
 
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -7,7 +7,7 @@ from hiredis import ReplyError
 
 # functions under test
 from reddish._core import Args, Command, MultiExec
-from reddish._core.errors import CommandError, TransactionError
+from reddish._core.errors import CommandError, TransactionError, ParseError
 
 from .strategies import complex_type, type_and_value
 
@@ -25,6 +25,16 @@ def test_repr():
 def test_command_parses_data(example):
     type_, value = example
     assert value == Command("foo").into(type_)._parse_response(value)
+
+
+def test_command_parsing_fails():
+    with pytest.raises(ParseError):
+        try:
+            Command("foo").into(int)._parse_response("hello")
+        except ParseError as error:
+            assert error.reply == "hello"
+            assert error.type is int
+            raise
 
 
 def test_empty_Command():

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2,9 +2,12 @@ import hiredis
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given
+from outcome import Value, Error
+from hiredis import ReplyError
 
 # functions under test
 from reddish._core import Args, Command, MultiExec
+from reddish._core.errors import CommandError, TransactionError
 
 from .strategies import complex_type, type_and_value
 
@@ -35,6 +38,16 @@ def test_command_serialization():
     assert [b"SET", b"foo", b"bar"] == reader.gets()
 
 
+def test_command_error():
+    with pytest.raises(CommandError):
+        try:
+            Command("foo")._parse_response(ReplyError("ERRORCODE some error message"))
+        except CommandError as error:
+            assert error.code == "ERRORCODE"
+            assert error.message == "some error message"
+            raise
+
+
 @given(num=st.integers(min_value=0, max_value=1000))
 def test_multi_exec_dump(num):
     reader = hiredis.Reader()
@@ -60,11 +73,40 @@ def tx():
     return MultiExec(Command("foo"), Command("bar"))
 
 
-def test_multi_exec_error(tx):
-    cause_error = Exception("cause")
-    exec_error = Exception("exec aborted")
-    [exec_error, cause_error] = tx._parse_response(
-        b"OK", b"QUEUED", cause_error, exec_error
+def test_multi_exec_EXECABORT(tx):
+    cause_error = ReplyError("SOME_ERROR some message")
+    exec_error = ReplyError(
+        "EXECABORT Transaction discarded because of previous errors."
+    )
+    with pytest.raises(CommandError):
+        try:
+            tx._parse_response(b"OK", b"QUEUED", cause_error, exec_error)
+        except CommandError as error:
+            cause = error.__cause__
+            assert isinstance(error.__cause__, CommandError)
+            assert cause.code == "SOME_ERROR"
+            raise
+
+
+def test_multi_exec_errors_in_transaction(tx):
+    with pytest.raises(TransactionError):
+        try:
+            tx._parse_response(
+                b"OK",
+                b"QUEUED",
+                b"QUEUED",
+                [b"PONG", ReplyError("ERRORCODE some error message")],
+            )
+        except TransactionError as error:
+            assert len(error.outcomes) == 2
+            first_reply, second_reply = error.outcomes
+            assert isinstance(first_reply, Value) and isinstance(second_reply, Error)
+            raise
+
+
+def test_multi_response_parsing(tx):
+    assert [b"foo", b"bar"] == tx._parse_response(
+        b"OK", b"QUEUED", b"QUEUED", [b"foo", b"bar"]
     )
 
 

--- a/tests/trio/test_trio.py
+++ b/tests/trio/test_trio.py
@@ -2,7 +2,7 @@ import trio
 import pytest_trio
 import pytest
 from reddish.trio import Redis, Command
-from reddish._core.errors import BrokenConnectionError
+from reddish._core.errors import ConnectionError
 
 
 @pytest_trio.trio_fixture
@@ -37,7 +37,7 @@ async def test_closed_connection(connection, ping):
     async with await connection as stream:
         redis = Redis(stream)
 
-    with pytest.raises(BrokenConnectionError):
+    with pytest.raises(ConnectionError):
         await redis.execute(ping)
 
 
@@ -51,5 +51,5 @@ async def test_cancellation(redis, ping):
     with trio.move_on_after(0.0001):  # break the connection
         await redis.execute(ping)
 
-    with pytest.raises(BrokenConnectionError):
+    with pytest.raises(ConnectionError):
         await redis.execute(ping)


### PR DESCRIPTION
`.execute` and `.execute_many` now raise exceptions instead of returning them as values. New exception types for dealing with redis error replies, parsing errors and errors within pipelines and transactions have been added. 